### PR TITLE
fix: too small tap area in pagination

### DIFF
--- a/apps/web/components/ui/Pagination/Pagination.vue
+++ b/apps/web/components/ui/Pagination/Pagination.vue
@@ -11,7 +11,7 @@
       :aria-label="$t('prevAriaLabel')"
       :disabled="pagination.selectedPage <= 1"
       variant="tertiary"
-      class="gap-3 !px-3 sm:px-6"
+      class="gap-3"
       @click="pagination.prev"
     >
       <template #prefix>
@@ -29,7 +29,7 @@
         >
           <button
             type="button"
-            class="px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
+            class="px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
             :aria-current="pagination.selectedPage === 1"
             @click="pagination.setPage(1)"
           >
@@ -48,7 +48,7 @@
         <div class="flex pt-1 border-t-4 border-transparent">
           <button
             type="button"
-            class="px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
+            class="px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
             :aria-current="pagination.endPage - 1 === pagination.selectedPage"
             @click="pagination.setPage(pagination.endPage - 1)"
           >
@@ -66,7 +66,7 @@
           <button
             type="button"
             :class="[
-              'px-3 sm:px-4 py-3 md:w-12 text-neutral-500 rounded-md hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900',
+              'px-4 py-3 md:w-12 text-neutral-500 rounded-md hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900',
               {
                 '!text-neutral-900 hover:!text-primary-800 active:!text-primary-900': pagination.selectedPage === page,
               },
@@ -83,7 +83,7 @@
         <div class="flex pt-1 border-t-4 border-transparent">
           <button
             type="button"
-            class="px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
+            class="px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
             :aria-label="$t('secondPageAriaLabel')"
             @click="pagination.setPage(2)"
           >
@@ -107,7 +107,7 @@
         >
           <button
             type="button"
-            class="px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
+            class="px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
             :aria-current="pagination.totalPages === pagination.selectedPage"
             @click="pagination.setPage(pagination.totalPages)"
           >
@@ -122,7 +122,7 @@
       :aria-label="$t('nextAriaLabel')"
       :disabled="pagination.selectedPage >= pagination.totalPages"
       variant="tertiary"
-      class="gap-3 !px-3 sm:px-6"
+      class="gap-3"
       @click="pagination.next"
     >
       <span class="hidden sm:inline-flex">{{ $t('next') }}</span>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

https://vsf.atlassian.net/browse/SV-94
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed tap target sizes for pagination buttons.

![Zrzut ekranu 2023-07-24 o 16 37 48](https://github.com/vuestorefront/storefront-nuxt3-boilerplate/assets/44862757/02f61e24-36a7-4d0d-96cd-c59d222b623a)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
