### PR TITLE
chore: replace sdk init with composable

### DIFF
--- a/apps/web/composables/useCart/useCart.ts
+++ b/apps/web/composables/useCart/useCart.ts
@@ -1,7 +1,7 @@
 import type { SfCart } from '@vue-storefront/unified-data-model';
 import { toRefs } from '@vueuse/shared';
 import type { UseCartReturn, UseCartState, FetchCard } from '~/composables/useCart/types';
-import { sdk } from '~/sdk';
+import { useSdk } from '~/sdk';
 
 /**
  * @description Composable for managing cart.
@@ -23,7 +23,7 @@ export const useCart: UseCartReturn = () => {
   const fetchCard: FetchCard = async () => {
     state.value.loading = true;
     try {
-      const { data, error } = await useAsyncData<SfCart>(() => sdk.commerce.getCart());
+      const { data, error } = await useAsyncData<SfCart>(() => useSdk().commerce.getCart());
       useHandleError(error.value);
       state.value.data = data.value;
       return data;

--- a/apps/web/composables/useCartShippingMethods/useCartShippingMethods.ts
+++ b/apps/web/composables/useCartShippingMethods/useCartShippingMethods.ts
@@ -4,7 +4,7 @@ import type {
   UseCartShippingMethodsReturn,
   GetShippingMethods,
 } from '~/composables/useCartShippingMethods/types';
-import { sdk } from '~/sdk';
+import { useSdk } from '~/sdk';
 
 /**
  * @description Composable for getting shipping methods.
@@ -26,7 +26,7 @@ export const useCartShippingMethods: UseCartShippingMethodsReturn = () => {
 
   const getShippingMethods: GetShippingMethods = async () => {
     state.value.loading = true;
-    const { data, error } = await useAsyncData(() => sdk.commerce.getShippingMethods());
+    const { data, error } = await useAsyncData(() => useSdk().commerce.getShippingMethods());
     useHandleError(error.value);
     state.value.data = data.value;
     state.value.loading = false;

--- a/apps/web/composables/useContent/useContent.ts
+++ b/apps/web/composables/useContent/useContent.ts
@@ -1,4 +1,4 @@
-import { sdk } from '~/sdk';
+import { useSdk } from '~/sdk';
 import type { UseContentReturn, UseContentState, GetContent } from './types';
 
 /**
@@ -22,7 +22,7 @@ export const useContent: UseContentReturn = (url) => {
   const getContent: GetContent = async () => {
     state.value.loading = true;
     try {
-      const { data, error } = await useAsyncData(() => sdk.commerce.getContent({ url }));
+      const { data, error } = await useAsyncData(() => useSdk().commerce.getContent({ url }));
       useHandleError(error.value);
       state.value.data = data.value;
       return data;

--- a/apps/web/composables/useProduct/useProduct.ts
+++ b/apps/web/composables/useProduct/useProduct.ts
@@ -1,5 +1,5 @@
 import { toRefs } from '@vueuse/shared';
-import { sdk } from '~/sdk';
+import { useSdk } from '~/sdk';
 import type { UseProductReturn, UseProductState, FetchProduct } from './types';
 
 /**
@@ -22,7 +22,7 @@ export const useProduct: UseProductReturn = (slug) => {
    */
   const fetchProduct: FetchProduct = async (slug) => {
     state.value.loading = true;
-    const { data, error } = await useAsyncData(() => sdk.commerce.getProduct({ slug }));
+    const { data, error } = await useAsyncData(() => useSdk().commerce.getProduct({ slug }));
     useHandleError(error.value);
     state.value.data = data.value;
     state.value.loading = false;

--- a/apps/web/composables/useProductRecommended/useProductRecommended.ts
+++ b/apps/web/composables/useProductRecommended/useProductRecommended.ts
@@ -4,7 +4,7 @@ import type {
   UseProductRecommendedState,
   FetchProductRecommended,
 } from '~/composables/useProductRecommended/types';
-import { sdk } from '~/sdk';
+import { useSdk } from '~/sdk';
 
 /**
  * Composable for getting recommended products data
@@ -23,7 +23,7 @@ export const useProductRecommended: UseProductRecommendedReturn = (slug) => {
    */
   const fetchProductRecommended: FetchProductRecommended = async (slug) => {
     state.value.loading = true;
-    const { data, error } = await useAsyncData(() => sdk.commerce.getProductRecommended({ slug }));
+    const { data, error } = await useAsyncData(() => useSdk().commerce.getProductRecommended({ slug }));
     useHandleError(error.value);
     state.value.data = data.value;
     state.value.loading = false;

--- a/apps/web/composables/useProductReviews/useProductReviews.ts
+++ b/apps/web/composables/useProductReviews/useProductReviews.ts
@@ -1,5 +1,5 @@
 import { toRefs } from '@vueuse/shared';
-import { sdk } from '~/sdk';
+import { useSdk } from '~/sdk';
 import type { UseProductReviews, UseProductReviewsState, FetchProductReviews } from './types';
 
 /**
@@ -22,7 +22,7 @@ export const useProductReviews: UseProductReviews = (slug) => {
    */
   const fetchProductReviews: FetchProductReviews = async (slug) => {
     state.value.loading = true;
-    const { data, error } = await useAsyncData(() => sdk.commerce.getProductReviews({ slug }));
+    const { data, error } = await useAsyncData(() => useSdk().commerce.getProductReviews({ slug }));
     useHandleError(error.value);
     state.value.data = data.value;
     state.value.loading = false;

--- a/apps/web/composables/useProducts/useProducts.ts
+++ b/apps/web/composables/useProducts/useProducts.ts
@@ -1,5 +1,5 @@
 import { FetchProducts, UseProductsReturn, UseProductsState } from '~/composables/useProducts/types';
-import { sdk } from '~/sdk';
+import { useSdk } from '~/sdk';
 
 /**
  * @description Composable for managing products.
@@ -20,7 +20,7 @@ export const useProducts: UseProductsReturn = () => {
    */
   const fetchProducts: FetchProducts = async () => {
     state.value.loading = true;
-    const { data, error } = await useAsyncData(sdk.commerce.getProducts);
+    const { data, error } = await useAsyncData(useSdk().commerce.getProducts);
     useHandleError(error.value);
     state.value.data = data.value;
     state.value.loading = false;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@vue-storefront/sdk": "^1.0.1",
     "@vue-storefront/storefront-boilerplate-sdk": "~0.1.0",
+    "@vueuse/core": "^10.3.0",
     "lodash-es": "^4.17.21"
   },
   "devDependencies": {

--- a/apps/web/sdk/index.ts
+++ b/apps/web/sdk/index.ts
@@ -1,8 +1,11 @@
 import { initSDK, buildModule } from '@vue-storefront/sdk';
 import { type SdkModule, sdkModule } from '@vue-storefront/storefront-boilerplate-sdk';
+import { createSharedComposable } from '@vueuse/core';
 
-const sdkConfig = {
-  commerce: buildModule<SdkModule>(sdkModule),
-};
+export const useSdk = createSharedComposable(() => {
+  const sdkConfig = {
+    commerce: buildModule<SdkModule>(sdkModule),
+  };
 
-export const sdk = initSDK<typeof sdkConfig>(sdkConfig);
+  return initSDK<typeof sdkConfig>(sdkConfig);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4366,6 +4366,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/web-bluetooth@npm:^0.0.17":
+  version: 0.0.17
+  resolution: "@types/web-bluetooth@npm:0.0.17"
+  checksum: 8c72ba8cd1d7abd3fcab608e1d8eb828420df23f67d783f1282d4a747f995e91a0c861f92fa195e9423edb22bb34854452028f8a68148a593b35915635a4f4db
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.0
   resolution: "@types/yargs-parser@npm:21.0.0"
@@ -5083,6 +5090,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vueuse/core@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "@vueuse/core@npm:10.3.0"
+  dependencies:
+    "@types/web-bluetooth": ^0.0.17
+    "@vueuse/metadata": 10.3.0
+    "@vueuse/shared": 10.3.0
+    vue-demi: ">=0.14.5"
+  checksum: 54af7ab9f2aff8cc795dfc9d846aa9a27dc0949d7a6eec79697819e7dc8cb17b1682f267e7501382afa45736b6877363e640e381b7ac1fd6bc18dc860911afd8
+  languageName: node
+  linkType: hard
+
 "@vueuse/core@npm:^9.12.0":
   version: 9.13.0
   resolution: "@vueuse/core@npm:9.13.0"
@@ -5095,10 +5114,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vueuse/metadata@npm:10.3.0":
+  version: 10.3.0
+  resolution: "@vueuse/metadata@npm:10.3.0"
+  checksum: fb5cb1ff730129ddd831e37cd6e7fed2ebc12211ed63c5075ecef7311852063a8eb152bb213459e36f7b69711f8da35835e2c0ece018c43700febf591ed96937
+  languageName: node
+  linkType: hard
+
 "@vueuse/metadata@npm:9.13.0":
   version: 9.13.0
   resolution: "@vueuse/metadata@npm:9.13.0"
   checksum: 91e137bf2fb1406587b523edae26b58b315d3a59797c9f2ed5dde9cb707026aa740b86da5955ea7f9662a93ce92249d0b3af763c65449b4a843bbd0725eb67f6
+  languageName: node
+  linkType: hard
+
+"@vueuse/shared@npm:10.3.0":
+  version: 10.3.0
+  resolution: "@vueuse/shared@npm:10.3.0"
+  dependencies:
+    vue-demi: ">=0.14.5"
+  checksum: 2392ce5c798ff2aa09c82de11fef3a6cc1eb3d198598e0f19f803645003003e06c90bc4cde5367200f8458a31344edcd4ab571b84a4f7d21ee8083b9309c9bf3
   languageName: node
   linkType: hard
 
@@ -18790,7 +18825,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-demi@npm:*":
+"vue-demi@npm:*, vue-demi@npm:>=0.14.5":
   version: 0.14.5
   resolution: "vue-demi@npm:0.14.5"
   peerDependencies:
@@ -18990,6 +19025,7 @@ __metadata:
     "@vue-storefront/storefront-boilerplate-sdk": ~0.1.0
     "@vue-storefront/unified-data-model": ^0.3.0
     "@vue/test-utils": ^2.4.0
+    "@vueuse/core": ^10.3.0
     happy-dom: ^9.20.3
     lodash-es: ^4.17.21
     nuxt: ^3.6.5


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

SDK initialisation needs to be added within a composable, because in the real-life scenario use would need to use environment variables when initialising SDK. And env variables are available in nuxt only via methods like `unseRuntimeConfig`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
