### PR TITLE
fix: remove createSharedComposable from sdk

### DIFF
--- a/apps/web/sdk/index.ts
+++ b/apps/web/sdk/index.ts
@@ -1,11 +1,10 @@
 import { initSDK, buildModule } from '@vue-storefront/sdk';
 import { type SdkModule, sdkModule } from '@vue-storefront/storefront-boilerplate-sdk';
-import { createSharedComposable } from '@vueuse/core';
 
-export const useSdk = createSharedComposable(() => {
+export const useSdk = () => {
   const sdkConfig = {
     commerce: buildModule<SdkModule>(sdkModule),
   };
 
   return initSDK<typeof sdkConfig>(sdkConfig);
-});
+};


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Using `createSharedComposable` make the composable context leak into the whole Nuxt server instance. It would be nice to create `createSharedForSingleNuxtRenderContextComposable` util and that should be handled part of [issue in the backlog](https://vsf.atlassian.net/browse/UST-763).

For now removal of `createSharedComposable` is the quickest fix.

More details are described [here](https://vsf.atlassian.net/wiki/spaces/DEAC/pages/237600775/Potential+shared+state+pitfall+with+createSharedComposable)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
