### PR TITLE
fix: use type import to fix typescript warnings

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-exec < /dev/tty && git cz --hook || true
+(exec < /dev/tty) && git cz --hook || true

--- a/apps/web/components/CategoryPageContent/types.ts
+++ b/apps/web/components/CategoryPageContent/types.ts
@@ -1,4 +1,4 @@
-import { SfProductCatalogItem } from '@vue-storefront/unified-data-model';
+import type { SfProductCatalogItem } from '@vue-storefront/unified-data-model';
 
 export type CategoryPageContentProps = {
   title: string;

--- a/apps/web/components/ProductProperties/ProductProperties.vue
+++ b/apps/web/components/ProductProperties/ProductProperties.vue
@@ -38,7 +38,7 @@
 
 <script setup lang="ts">
 import { SfChip, SfThumbnail } from '@storefront-ui/vue';
-import { ProductPropertiesProps } from '~/components/ProductProperties/types';
+import type { ProductPropertiesProps } from '~/components/ProductProperties/types';
 
 const props = defineProps<ProductPropertiesProps>();
 

--- a/apps/web/components/RecommendedProducts/types.ts
+++ b/apps/web/components/RecommendedProducts/types.ts
@@ -1,4 +1,4 @@
-import { SfProduct } from '@vue-storefront/unified-data-model';
+import type { SfProduct } from '@vue-storefront/unified-data-model';
 
 export type RecommendedProductsProps = {
   products: SfProduct[];

--- a/apps/web/composables/useCartShippingMethods/types.ts
+++ b/apps/web/composables/useCartShippingMethods/types.ts
@@ -1,4 +1,4 @@
-import { SfShippingMethods, Maybe } from '@vue-storefront/unified-data-model';
+import type { SfShippingMethods, Maybe } from '@vue-storefront/unified-data-model';
 
 export interface UseCartShippingMethodsState {
   data: Maybe<SfShippingMethods>;

--- a/apps/web/composables/useCustomerReturns/types.ts
+++ b/apps/web/composables/useCustomerReturns/types.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue';
-import { Maybe } from '@vue-storefront/unified-data-model';
+import type { Maybe } from '@vue-storefront/unified-data-model';
 
 export interface UseCustomerReturnsState {
   data: Maybe<unknown[]>;

--- a/apps/web/composables/useProductAttribute/useProductAttribute.ts
+++ b/apps/web/composables/useProductAttribute/useProductAttribute.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { SfAttribute, SfProduct } from '@vue-storefront/unified-data-model';
+import type { SfAttribute, SfProduct } from '@vue-storefront/unified-data-model';
 import { groupBy, uniqBy } from 'lodash-es';
 
 /**

--- a/apps/web/composables/useProducts/types.ts
+++ b/apps/web/composables/useProducts/types.ts
@@ -1,4 +1,4 @@
-import { Ref } from 'vue';
+import type { Ref } from 'vue';
 import type { GetProducts } from '@vue-storefront/storefront-boilerplate-sdk';
 import type { Maybe } from '@vue-storefront/unified-data-model';
 

--- a/apps/web/composables/useProducts/useProducts.ts
+++ b/apps/web/composables/useProducts/useProducts.ts
@@ -1,4 +1,4 @@
-import { FetchProducts, UseProductsReturn, UseProductsState } from '~/composables/useProducts/types';
+import type { FetchProducts, UseProductsReturn, UseProductsState } from '~/composables/useProducts/types';
 import { useSdk } from '~/sdk';
 
 /**

--- a/apps/web/layouts/default.vue
+++ b/apps/web/layouts/default.vue
@@ -133,7 +133,7 @@ import {
   SfModal,
   useDisclosure,
 } from '@storefront-ui/vue';
-import { DefaultLayoutProps } from '~/layouts/types';
+import type { DefaultLayoutProps } from '~/layouts/types';
 
 defineProps<DefaultLayoutProps>();
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Simply fix typescript warnings when building the app about importing types

